### PR TITLE
Fix: update clipboard copy functionality to use alias instead of customAddress

### DIFF
--- a/src/components/CustomAddressRow.tsx
+++ b/src/components/CustomAddressRow.tsx
@@ -113,7 +113,7 @@ const CustomAddressRow: React.FC<Props> = (props) => {
                     props.onChange(updatedCustomAddress, "insert");
                 }
 
-                navigator.clipboard.writeText(customAddress.from)
+                navigator.clipboard.writeText(alias)
                 toast({
                     title: `${alias} copied to clipboard`
                 })


### PR DESCRIPTION
customAddress wasn't available at time the form is submitted because it's async. So the new address wasn't actually getting copied to clipboard.